### PR TITLE
Added overcommit

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,30 @@
+# Use this file to configure the Overcommit hooks you wish to use. This will
+# extend the default configuration defined in:
+# https://github.com/sds/overcommit/blob/master/config/default.yml
+#
+# At the topmost level of this YAML file is a key representing type of hook
+# being run (e.g. pre-commit, commit-msg, etc.). Within each type you can
+# customize each hook, such as whether to only run it on certain files (via
+# `include`), whether to only display output if it fails (via `quiet`), etc.
+#
+# For a complete list of hooks, see:
+# https://github.com/sds/overcommit/tree/master/lib/overcommit/hook
+#
+# For a complete list of options that you can use to customize hooks, see:
+# https://github.com/sds/overcommit#configuration
+#
+# Uncomment the following lines to make the configuration take effect.
+
+PreCommit:
+  RuboCop:
+    enabled: true
+    on_warn: fail
+    command: ['bundle', 'exec', 'rubocop']
+  Fasterer:
+    enabled: true
+    on_warn: fail
+    problem_on_unmodified_line: ignore
+    command: ['bundle', 'exec', 'fasterer']
+  BundleAudit:
+    enabled: true
+    command: ['bundle', 'exec', 'bundler-audit', 'check', '--update']

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'puma', '~> 6.0'
 
 gem 'propshaft'
 gem 'jsbundling-rails'
+gem 'overcommit', '~> 0.60.0'
 gem 'turbo-rails'
 gem 'stimulus-rails'
 gem 'cssbundling-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       marcel (~> 1.0.0)
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
+    childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.3.0)
@@ -116,6 +117,7 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    iniparse (1.5.0)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -158,6 +160,10 @@ GEM
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    overcommit (0.60.0)
+      childprocess (>= 0.6.3, < 5)
+      iniparse (~> 1.4)
+      rexml (~> 3.2)
     pagy (6.0.2)
     parallel (1.22.1)
     parser (3.2.1.1)
@@ -324,6 +330,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   letter_opener
+  overcommit (~> 0.60.0)
   pagy
   pg (~> 1.4.5)
   propshaft


### PR DESCRIPTION
Added overcommit gem with:
- rubocop
- fasterer
- bundler-audit

Howto init overcommit at the first time:
`overcommit --install`
`overcommit --sign`

How to skip (only if very needed):
`SKIP=RuboCop git commit`