### PR TITLE
hide square and tick in checkbox

### DIFF
--- a/app/assets/stylesheets/home.sass.scss
+++ b/app/assets/stylesheets/home.sass.scss
@@ -202,6 +202,9 @@
             font-size: 14px;
           }
         }
+        [type="checkbox"]{
+          display: none;
+        }
       }
       .filter-search {
         width: 100%;


### PR DESCRIPTION
- Hide square and tick in the checkbox on the home page in the filter panel