### PR TITLE
ci: fix Claude PR review (model + allowedTools, guard huge PRs)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --model opus
+            --allowedTools "Bash,Read,Write,Edit"
           prompt: |
             You are a senior Rails engineer reviewing a PR for a web platform with admin panel.
 
@@ -42,6 +45,8 @@ jobs:
             1. `gh pr diff ${{ github.event.issue.number }}` — to get the diff
             2. `gh pr view ${{ github.event.issue.number }}` — to get PR title/description
             3. `COMMIT_SHA=$(gh pr view ${{ github.event.issue.number }} --json headRefOid -q .headRefOid)` — to get the head commit SHA
+
+            If the diff is very large (e.g. a release/integration PR with 150+ changed files), do NOT review it line by line: focus on the highest-risk files and changes, and note in the summary that the review was limited to a subset of the diff.
 
             Then for EACH issue found, post a SEPARATE inline comment on the exact line:
             `gh api repos/$GITHUB_REPOSITORY/pulls/${{ github.event.issue.number }}/comments --method POST -f body="<comment>" -f commit_id="$COMMIT_SHA" -f path="<file>" -F line=<line> -f side="RIGHT"`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,12 +137,12 @@ GEM
     childprocess (5.1.0)
       logger (~> 1.5)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
     csv (3.3.5)
@@ -245,7 +245,7 @@ GEM
     msgpack (1.8.0)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -260,11 +260,11 @@ GEM
       net-protocol
     net-ssh (7.3.2)
     nio4r (2.7.5)
-    nokogiri (1.19.3-x64-mingw-ucrt)
+    nokogiri (1.19.4-x64-mingw-ucrt)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-darwin)
+    nokogiri (1.19.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     ostruct (0.6.3)
@@ -304,7 +304,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (8.0.1)
+    puma (8.0.2)
       nio4r (~> 2.0)
     pundit (2.5.2)
       activesupport (>= 3.0.0)


### PR DESCRIPTION
Pass `--model opus` + `--allowedTools "Bash,Read,Write,Edit"` to claude-code-action so the reviewer can actually write comment files / run `gh`, and add a prompt guard to review huge PRs selectively. Same fix applied across the other bot repos.